### PR TITLE
feat: make antspyx an optional extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.0 (2026-06-30)
+
+### Feat
+
+- make antspyx an optional extra; install `aind-anatomical-utils[ants]` for the ANTs code paths (`ants_volume`, `AnatomicalHeader.as_ants`)
+
 ## v0.4.3 (2026-06-30)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,16 @@ authors = [
 ]
 classifiers = ["Programming Language :: Python :: 3"]
 readme = "README.md"
-version = "0.4.3"
+version = "0.5.0"
 
-dependencies = ["numpy>=1.7", "SimpleITK>=2", "antspyx>=0.6.2"]
+dependencies = ["numpy>=1.7", "SimpleITK>=2"]
+
+[project.optional-dependencies]
+# ANTs (antspyx) is a heavy, resolution-fragile dependency used only by the
+# ants_volume module and AnatomicalHeader.as_ants. Consumers that need those
+# paths install `aind-anatomical-utils[ants]`; everyone else sheds antspyx and
+# its scipy/scikit-image/ITK subtree entirely.
+ants = ["antspyx>=0.6.2"]
 
 [project.urls]
 Repository = "https://github.com/AllenNeuralDynamics/aind-anatomical-utils/"
@@ -25,7 +32,9 @@ Changelog = "https://github.com/AllenNeuralDynamics/aind-anatomical-utils/blob/m
 
 [dependency-groups]
 types = ["mypy"]
-dev = [{ include-group = "types" }, "codespell", "pytest", "pytest-cov", "ruff", "interrogate"]
+# antspyx is kept in the dev group (not a consumer dependency) so this repo's
+# own tests still exercise the ANTs code paths; the ANTs tests importorskip it.
+dev = [{ include-group = "types" }, "codespell", "pytest", "pytest-cov", "ruff", "interrogate", "antspyx>=0.6.2"]
 jupyter = [{ include-group = "dev" }, "ipykernel", "pip"]
 docs = [
   { include-group = "dev" },
@@ -47,7 +56,8 @@ extend-exclude = ["scratch"]
 [tool.ruff.lint]
 extend-select = ["Q", "RUF100", "C90", "I", "F", "E", "W", "D", "UP", "ANN", "PYI"]
 extend-ignore = ["ANN401"]  # Skip self/cls type annotations
-per-file-ignores = { "tests/*.py" = ["ANN", "D"] }
+# E402: ANTs test modules run pytest.importorskip("ants") before importing ants.
+per-file-ignores = { "tests/*.py" = ["ANN", "D", "E402"] }
 mccabe = { max-complexity = 14 }
 pydocstyle = { convention = "numpy" }
 

--- a/src/aind_anatomical_utils/anatomical_volume.py
+++ b/src/aind_anatomical_utils/anatomical_volume.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from itertools import product
 from typing import TYPE_CHECKING, cast
 
-import ants  # type: ignore[import-untyped]
 import numpy as np
 import SimpleITK as sitk
 from numpy.typing import DTypeLike, NDArray
@@ -194,6 +193,13 @@ class AnatomicalHeader:
             A new image with this :class:`Header`'s origin, spacing, direction,
             and size set. Pixel type is ``unsigned char``.
         """
+        try:
+            import ants  # type: ignore[import-untyped]
+        except ModuleNotFoundError as e:  # pragma: no cover
+            raise ModuleNotFoundError(
+                "AnatomicalHeader.as_ants requires the 'ants' extra: pip install 'aind-anatomical-utils[ants]'"
+            ) from e
+
         arr = np.zeros(self.size_ijk, dtype=np_eltype)
         img = ants.from_numpy(
             arr,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 """Shared test utilities for regrid functions across libraries."""
 
-import ants  # type: ignore[import-untyped]
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
-from ants.core import ANTsImage
 from SimpleITK import DICOMOrientImageFilter
+
+if TYPE_CHECKING:
+    from ants.core import ANTsImage
 
 # ============================================================================
 # Shared Gradient Pattern Creation
@@ -37,6 +42,8 @@ def create_gradient_ants_image(
     ANTsImage
         Gradient test image
     """
+    import ants  # type: ignore[import-untyped]
+
     # Create gradient pattern: value = i + 100*j + 10000*k
     arr = np.zeros(size, dtype=np.int32)
     for i in range(size[0]):

--- a/tests/test_anatomical_volume.py
+++ b/tests/test_anatomical_volume.py
@@ -2,9 +2,12 @@
 
 import unittest
 
+import pytest
+
+pytest.importorskip("ants")
+
 import ants  # type: ignore[import-untyped]
 import numpy as np
-import pytest
 import SimpleITK as sitk
 from SimpleITK import DICOMOrientImageFilter
 

--- a/tests/test_ants_volume.py
+++ b/tests/test_ants_volume.py
@@ -2,6 +2,10 @@
 
 import unittest
 
+import pytest
+
+pytest.importorskip("ants")
+
 import ants  # type: ignore[import-untyped]
 import numpy as np
 

--- a/tests/test_optional_ants.py
+++ b/tests/test_optional_ants.py
@@ -1,0 +1,34 @@
+"""Guard the package's ANTs-free import contract.
+
+``antspyx`` is an optional extra (``aind-anatomical-utils[ants]``). The ANTs-free
+modules and ``anatomical_volume`` must import without it; only the ANTs code
+paths (``ants_volume`` and ``AnatomicalHeader.as_ants``) may require it.
+"""
+
+import subprocess
+import sys
+
+
+def test_anatomical_volume_import_does_not_pull_ants() -> None:
+    """Importing anatomical_volume must not import the ``ants`` module.
+
+    A top-level ``import ants`` re-introduced into ``anatomical_volume`` would
+    silently make ANTs a hard dependency again. Runs in a fresh subprocess so an
+    ``ants`` already imported by the parent test session cannot mask a regression.
+    """
+    code = (
+        "import sys\n"
+        "import aind_anatomical_utils.anatomical_volume\n"
+        "assert 'ants' not in sys.modules, 'anatomical_volume imported ants at module load'\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_ants_free_public_modules_import() -> None:
+    """The ANTs-free public modules must import without antspyx present."""
+    code = (
+        "import aind_anatomical_utils\n"
+        "from aind_anatomical_utils import slicer, coordinate_systems, sitk_volume, utils\n"
+        "from aind_anatomical_utils.anatomical_volume import AnatomicalHeader, fix_corner_compute_origin\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/uv.lock
+++ b/uv.lock
@@ -31,17 +31,22 @@ wheels = [
 
 [[package]]
 name = "aind-anatomical-utils"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
-    { name = "antspyx" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "simpleitk" },
 ]
 
+[package.optional-dependencies]
+ants = [
+    { name = "antspyx" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "antspyx" },
     { name = "codespell" },
     { name = "interrogate" },
     { name = "mypy" },
@@ -50,6 +55,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "antspyx" },
     { name = "codespell" },
     { name = "furo" },
     { name = "interrogate" },
@@ -68,6 +74,7 @@ docs = [
     { name = "sphinx-copybutton" },
 ]
 jupyter = [
+    { name = "antspyx" },
     { name = "codespell" },
     { name = "interrogate" },
     { name = "ipykernel" },
@@ -83,13 +90,15 @@ types = [
 
 [package.metadata]
 requires-dist = [
-    { name = "antspyx", specifier = ">=0.6.2" },
+    { name = "antspyx", marker = "extra == 'ants'", specifier = ">=0.6.2" },
     { name = "numpy", specifier = ">=1.7" },
     { name = "simpleitk", specifier = ">=2" },
 ]
+provides-extras = ["ants"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "antspyx", specifier = ">=0.6.2" },
     { name = "codespell" },
     { name = "interrogate" },
     { name = "mypy" },
@@ -98,6 +107,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "antspyx", specifier = ">=0.6.2" },
     { name = "codespell" },
     { name = "furo" },
     { name = "interrogate" },
@@ -111,6 +121,7 @@ docs = [
     { name = "sphinx-copybutton" },
 ]
 jupyter = [
+    { name = "antspyx", specifier = ">=0.6.2" },
     { name = "codespell" },
     { name = "interrogate" },
     { name = "ipykernel" },


### PR DESCRIPTION
antspyx is heavy and resolution-fragile (it pins scipy<1.16, which makes downstream projects with an unbounded numpy backtrack scipy to an ancient version that fails to build on Python >=3.12). It is only needed by the ants_volume module and AnatomicalHeader.as_ants, so move it out of the hard runtime dependencies into an optional extra.

- pyproject: antspyx -> [project.optional-dependencies] `ants`; keep it in the dev group so this repo's own tests still exercise the ANTs paths
- anatomical_volume: drop the top-level `import ants`; import it lazily inside as_ants with a friendly ModuleNotFoundError pointing at the `ants` extra
- conftest: import ants lazily / under TYPE_CHECKING so ANTs-free test collection works
- ANTs test modules: pytest.importorskip("ants") so they skip without antspyx
- add test_optional_ants: guards that importing anatomical_volume does not pull ants, and that the ANTs-free public surface imports
- bump 0.4.3 -> 0.5.0 (dropping a previously-transitive dep is consumer-visible)

Downstream consumers that use only slicer/coordinate_systems/sitk_volume/utils now shed antspyx and its scipy/scikit-image/ITK subtree. ANTs consumers install aind-anatomical-utils[ants].